### PR TITLE
Update outstandingrpc.ksh

### DIFF
--- a/outstandingrpc.ksh
+++ b/outstandingrpc.ksh
@@ -1,7 +1,9 @@
-#!/bin/ksh 
-#https://access.redhat.com/solutions/69248
-while true; do 
-    grep "xprt:" /proc/self/mountstats  | awk '{print $9,$11,$12,$8}' | tail -1 | while read i; do
+!/usr/bin/ksh
+
+mountpoint="repro"
+
+while true; do
+    grep -A 20 $mountpoint /proc/self/mountstats | grep "xprt:"  | awk '{print $9,$11,$12,$8}' | tail -1 | while read i; do
        divisor=`echo $i | awk '{print $1}'`
        avg_flight=`echo $i | awk '{print $2}'`
        backlog=`echo $i | awk '{print $3}'`
@@ -12,17 +14,5 @@ while true; do
        (( cf = cur_flight  - divisor ))
        echo "Avg_RPC_In_Filght: $aif, Avg_Backlog: $bl,  Current_in_flight: $cf"
        sleep 1
-
     done
- 
-#xprt: tcp 806 1 1 0 12 525556 525556 0 65784746 13192742420 128 1150041 65259209
-#1     2   3   4 5 6 7  8      9     10 11       12          13   14     15
 done
-
-
-#Average in-flight RPC requests: 65784746 / 525556 = 125.171o
-#                                 11        9
-#Average RPC backlog during sends: 13192742420 / 525556 = 25102
-#                                  12             9
-#Current In-flight RPC requests: 525556 - 525556 = 0 (when the statistic was taken, the connection was idle).
-                                 8        9

--- a/outstandingrpc.ksh
+++ b/outstandingrpc.ksh
@@ -1,6 +1,6 @@
 !/usr/bin/ksh
 
-mountpoint="repro"
+mountpoint="$1"
 
 while true; do
     grep -A 20 $mountpoint /proc/self/mountstats | grep "xprt:"  | awk '{print $9,$11,$12,$8}' | tail -1 | while read i; do


### PR DESCRIPTION
Updated to allow a mountpoint to be specified. This will allow only checking outstanding RPC for a specific mountpoint, instead of the last mountpoint with xprt:.